### PR TITLE
Fix broken link to reaction docs Create a theme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Reaction Commerce example theme plugin.
 Install this theme in `imports/plugins/custom/` to activate it.
 
 # Customization Guide
-- [Creating a theme](https://docs.reactioncommerce.com/reaction-docs/master/creating-a-theme-package)
+- [Creating a theme](https://docs.reactioncommerce.com/reaction-docs/master/creating-a-theme)
 - [Customization guide](https://docs.reactioncommerce.com/reaction-docs/master/tutorial)


### PR DESCRIPTION
Correct link url from https://docs.reactioncommerce.com/reaction-docs/master/creating-a-theme-package to https://docs.reactioncommerce.com/reaction-docs/master/creating-a-theme